### PR TITLE
Add note about cloning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ cd scratch-gui
 npm install
 ```
 
+**You may want to add `--depth=1` to the `git clone` command because there are some [large files in the git repository history](https://github.com/LLK/scratch-gui/issues/5140)**
+
 ## Getting started
 Running the project requires Node.js to be installed.
 


### PR DESCRIPTION
Because there are some very large files in the repository history

### Resolves

Workaround for #5140

### Proposed Changes

Add a note to the README about cloning with minimum depth

### Reason for Changes

So people don't have to wait such a long time to clone the repository